### PR TITLE
Handle private repos counts not available to non-organization member

### DIFF
--- a/changelog/fix-private-repo-counts.md
+++ b/changelog/fix-private-repo-counts.md
@@ -1,4 +1,4 @@
-Fix: Handle private repos counts not available to non-organization member
+Bugfix: Handle private repos counts not available to non-organization member
 
 Fix the case where the account used to query GitHub API is not a member of a
 given organisation, it resulted in a segfault.

--- a/changelog/fix-private-repo-counts.md
+++ b/changelog/fix-private-repo-counts.md
@@ -1,5 +1,6 @@
 Fix: Handle private repos counts not available to non-organization member
-[#18](https://github.com/promhippie/github_exporter/issues/18)
 
-Bug fix the case where the account used to query Github API is not a member of a given
-organisation. The resulted in segfault before the fix
+Fix the case where the account used to query GitHub API is not a member of a
+given organisation, it resulted in a segfault.
+
+https://github.com/promhippie/github_exporter/pull/18

--- a/changelog/fix-private-repo-counts.md
+++ b/changelog/fix-private-repo-counts.md
@@ -1,0 +1,5 @@
+Fix: Handle private repos counts not available to non-organization member
+[#18](https://github.com/promhippie/github_exporter/issues/18)
+
+Bug fix the case where the account used to query Github API is not a member of a given
+organisation. The resulted in segfault before the fix

--- a/pkg/exporter/org.go
+++ b/pkg/exporter/org.go
@@ -208,19 +208,23 @@ func (c *OrgCollector) Collect(ch chan<- prometheus.Metric) {
 			)
 		}
 
-		ch <- prometheus.MustNewConstMetric(
-			c.PrivateReposTotal,
-			prometheus.GaugeValue,
-			float64(*record.TotalPrivateRepos),
-			labels...,
-		)
+		if record.TotalPrivateRepos != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.PrivateReposTotal,
+				prometheus.GaugeValue,
+				float64(*record.TotalPrivateRepos),
+				labels...,
+			)
+		}
 
-		ch <- prometheus.MustNewConstMetric(
-			c.PrivateReposOwned,
-			prometheus.GaugeValue,
-			float64(*record.OwnedPrivateRepos),
-			labels...,
-		)
+		if record.OwnedPrivateRepos != nil {
+			ch <- prometheus.MustNewConstMetric(
+				c.PrivateReposOwned,
+				prometheus.GaugeValue,
+				float64(*record.OwnedPrivateRepos),
+				labels...,
+			)
+		}
 
 		ch <- prometheus.MustNewConstMetric(
 			c.Created,


### PR DESCRIPTION
When the `GITHUB_EXPORTER_TOKEN` is for a user who is not a member of a targeted organization, we get a crash 😄 
