### PR TITLE
Add flag to set /metrics endpoint request timeout

### DIFF
--- a/changelog/server-timeouts.md
+++ b/changelog/server-timeouts.md
@@ -1,0 +1,7 @@
+Feature: Add flag to set /metrics endpoint request timeout
+[#20](https://github.com/promhippie/github_exporter/issues/20)
+
+When pulling a lot of data from the Github API, in some cases the default 10s timeout on the
+`/metrics` endpoint can be insufficient.
+
+This option allows the timeout to be configured via `GITHUB_EXPORTER_SERVER_TIMEOUT`

--- a/changelog/server-timeouts.md
+++ b/changelog/server-timeouts.md
@@ -1,7 +1,7 @@
-Feature: Add flag to set /metrics endpoint request timeout
-[#20](https://github.com/promhippie/github_exporter/issues/20)
+Enhancement: Add flag to set /metrics endpoint request timeout
 
-When pulling a lot of data from the Github API, in some cases the default 10s timeout on the
-`/metrics` endpoint can be insufficient.
+When pulling a lot of data from the GitHub API, in some cases the default 10s 
+timeout on the `/metrics` endpoint can be insufficient. This option allows the
+timeout to be configured via `GITHUB_EXPORTER_SERVER_TIMEOUT`
 
-This option allows the timeout to be configured via `GITHUB_EXPORTER_SERVER_TIMEOUT`
+https://github.com/promhippie/github_exporter/pull/20

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -125,7 +125,10 @@ GITHUB_EXPORTER_WEB_PATH
 : Path to bind the metrics server, defaults to `/metrics`
 
 GITHUB_EXPORTER_REQUEST_TIMEOUT
-: Request timeout as duration, defaults to `5s`
+: Request to Github timeout, defaults to `5s`
+
+GITHUB_EXPORTER_SERVER_TIMEOUT
+: Prometheus /metrics endpoint timeout, defaults to `10s`
 
 GITHUB_EXPORTER_TOKEN
 : Access token for the GitHub API

--- a/pkg/action/server.go
+++ b/pkg/action/server.go
@@ -60,7 +60,7 @@ func Server(cfg *config.Config, logger log.Logger) error {
 			Addr:         cfg.Server.Addr,
 			Handler:      handler(cfg, logger, client),
 			ReadTimeout:  5 * time.Second,
-			WriteTimeout: 10 * time.Second,
+			WriteTimeout: cfg.Server.Timeout,
 		}
 
 		gr.Add(func() error {

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -61,9 +61,16 @@ func Run() error {
 				Destination: &cfg.Server.Path,
 			},
 			&cli.DurationFlag{
+				Name:        "server.timeout",
+				Value:       10 * time.Second,
+				Usage:       "Timeout serving Prometheus /metrics endpoint",
+				EnvVars:     []string{"GITHUB_EXPORTER_SERVER_TIMEOUT"},
+				Destination: &cfg.Server.Timeout,
+			},
+			&cli.DurationFlag{
 				Name:        "request.timeout",
 				Value:       5 * time.Second,
-				Usage:       "Request timeout as duration",
+				Usage:       "Timeout requesting Github API",
 				EnvVars:     []string{"GITHUB_EXPORTER_REQUEST_TIMEOUT"},
 				Destination: &cfg.Target.Timeout,
 			},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,8 +8,9 @@ import (
 
 // Server defines the general server configuration.
 type Server struct {
-	Addr string
-	Path string
+	Addr    string
+	Path    string
+	Timeout time.Duration
 }
 
 // Logs defines the level and color for log configuration.


### PR DESCRIPTION
When pulling a lot of data from the Github API, I found the default 10s timeout on the `/metrics` endpoint was insufficient. This option allows it to be configured via `GITHUB_EXPORTER_SERVER_TIMEOUT`