### PR TITLE
Rename flags and fix non-enterprise usage

### DIFF
--- a/changelog/unreleased/insecure-tls.md
+++ b/changelog/unreleased/insecure-tls.md
@@ -3,6 +3,6 @@ Enhancement: Allow insecure TLS via CLI flag
 In some cases it can be desirable to ignore certificate errors from the GitHub
 API - such as in the case of connecting to a private instance of GitHub
 Enterprise which uses a self-signed cert. This is exposed via the environment
-variable `GITHUB_EXPORTER_TLS_INSECURE` and the flag `--tls.insecure`.
+variable `GITHUB_EXPORTER_TLS_INSECURE` and the flag `--github.insecure`.
 
 https://github.com/promhippie/github_exporter/pull/19

--- a/changelog/unreleased/server-timeouts.md
+++ b/changelog/unreleased/server-timeouts.md
@@ -1,7 +1,7 @@
 Enhancement: Add flag to set /metrics endpoint request timeout
 
-When pulling a lot of data from the GitHub API, in some cases the default 10s 
+When pulling a lot of data from the GitHub API, in some cases the default 10s
 timeout on the `/metrics` endpoint can be insufficient. This option allows the
-timeout to be configured via `GITHUB_EXPORTER_SERVER_TIMEOUT`
+timeout to be configured via `GITHUB_EXPORTER_WEB_TIMEOUT` or `--web.timeout`
 
 https://github.com/promhippie/github_exporter/pull/20

--- a/docs/content/getting-started.md
+++ b/docs/content/getting-started.md
@@ -124,20 +124,20 @@ GITHUB_EXPORTER_WEB_ADDRESS
 GITHUB_EXPORTER_WEB_PATH
 : Path to bind the metrics server, defaults to `/metrics`
 
-GITHUB_EXPORTER_TLS_INSECURE
-: Skip host verify on TLS connection, defaults to `false`
+GITHUB_EXPORTER_WEB_TIMEOUT
+: Server metrics endpoint timeout, defaults to `10s`
 
 GITHUB_EXPORTER_REQUEST_TIMEOUT
 : Request to Github timeout, defaults to `5s`
-
-GITHUB_EXPORTER_SERVER_TIMEOUT
-: Server metrics endpoint timeout, defaults to `10s`
 
 GITHUB_EXPORTER_TOKEN
 : Access token for the GitHub API
 
 GITHUB_EXPORTER_BASE_URL
-: URL to access the GitHub API, defaults to `https://api.github.com/`
+: URL to access the GitHub Enterprise API
+
+GITHUB_EXPORTER_TLS_INSECURE
+: Skip TLS verification for GitHub Enterprise, defaults to `false`
 
 GITHUB_EXPORTER_ENTERPRISE
 : Enterprises to scrape metrics from, comma-separated list

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -60,18 +60,11 @@ func Run() error {
 				EnvVars:     []string{"GITHUB_EXPORTER_WEB_PATH"},
 				Destination: &cfg.Server.Path,
 			},
-			&cli.BoolFlag{
-				Name:        "tls.insecure",
-				Value:       false,
-				Usage:       "Skip host verify on TLS connection",
-				EnvVars:     []string{"GITHUB_EXPORTER_TLS_INSECURE"},
-				Destination: &cfg.Server.Insecure,
-			},
 			&cli.DurationFlag{
-				Name:        "server.timeout",
+				Name:        "web.timeout",
 				Value:       10 * time.Second,
 				Usage:       "Server metrics endpoint timeout",
-				EnvVars:     []string{"GITHUB_EXPORTER_SERVER_TIMEOUT"},
+				EnvVars:     []string{"GITHUB_EXPORTER_WEB_TIMEOUT"},
 				Destination: &cfg.Server.Timeout,
 			},
 			&cli.DurationFlag{
@@ -90,10 +83,17 @@ func Run() error {
 			},
 			&cli.StringFlag{
 				Name:        "github.baseurl",
-				Value:       "https://api.github.com/",
-				Usage:       "URL to access the GitHub API",
+				Value:       "",
+				Usage:       "URL to access the GitHub Enterprise API",
 				EnvVars:     []string{"GITHUB_EXPORTER_BASE_URL"},
 				Destination: &cfg.Target.BaseURL,
+			},
+			&cli.BoolFlag{
+				Name:        "github.insecure",
+				Value:       false,
+				Usage:       "Skip TLS verification for GitHub Enterprise",
+				EnvVars:     []string{"GITHUB_EXPORTER_INSECURE"},
+				Destination: &cfg.Target.Insecure,
 			},
 			&cli.StringSliceFlag{
 				Name:        "github.enterprise",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -8,10 +8,9 @@ import (
 
 // Server defines the general server configuration.
 type Server struct {
-	Addr     string
-	Path     string
-	Timeout  time.Duration
-	Insecure bool
+	Addr    string
+	Path    string
+	Timeout time.Duration
 }
 
 // Logs defines the level and color for log configuration.
@@ -24,6 +23,7 @@ type Logs struct {
 type Target struct {
 	Token       string
 	BaseURL     string
+	Insecure    bool
 	Enterprises cli.StringSlice
 	Orgs        cli.StringSlice
 	Repos       cli.StringSlice


### PR DESCRIPTION
@mafrosis I have renamed some flags introduced by you before the release, it's matching better the naming of the existing flags. Beside that I had to fix the regular GitHub usage, requesting information from github.com had been broken otherwise.