### PR TITLE
Added workflow run created duration metric and query configs

### DIFF
--- a/changelog/unreleased/workflow-run-created-metric.md
+++ b/changelog/unreleased/workflow-run-created-metric.md
@@ -1,0 +1,10 @@
+Enhancement: New metrics and configurations for the workflow collector
+
+1. Added a new metric for the duration, in minutes, of the time since the run was created:
+github_workflow_duration_run_created_minutes
+2. Added 2 optional configuration options for the workflows exporter:
+    1. Query workflows with a specific status (Default to any)
+    2. Set the window history (defaults to 12 hours)
+3. Added run_id label
+
+https://github.com/promhippie/github_exporter/pull/200

--- a/docs/partials/envvars.md
+++ b/docs/partials/envvars.md
@@ -67,11 +67,5 @@ GITHUB_EXPORTER_COLLECTOR_BILLING
 GITHUB_EXPORTER_COLLECTOR_WORKFLOWS
 : Enable collector for workflows, defaults to `false`
 
-GITHUB_EXPORTER_WORKFLOWS_STATUS
-: Query workflows with specific status, defaults to `""` (any status)
-
-GITHUB_EXPORTER_WORKFLOWS_HISTORY_WINDOW
-: Duration for querying workflows since the time they were created, defaults to `12h`
-
 GITHUB_EXPORTER_COLLECTOR_RUNNERS
 : Enable collector for runners, defaults to `false`

--- a/docs/partials/envvars.md
+++ b/docs/partials/envvars.md
@@ -67,5 +67,10 @@ GITHUB_EXPORTER_COLLECTOR_BILLING
 GITHUB_EXPORTER_COLLECTOR_WORKFLOWS
 : Enable collector for workflows, defaults to `false`
 
+GITHUB_EXPORTER_WORKFLOWS_STATUS
+: Query workflows with specific status, defaults to `""` (any status)
+
+GITHUB_EXPORTER_WORKFLOWS_HISTORY_WINDOW
+: Number of minutes to go back when querying for workflows since the time they were created, defaults to `720` (12 hours)
 GITHUB_EXPORTER_COLLECTOR_RUNNERS
 : Enable collector for runners, defaults to `false`

--- a/docs/partials/envvars.md
+++ b/docs/partials/envvars.md
@@ -71,6 +71,7 @@ GITHUB_EXPORTER_WORKFLOWS_STATUS
 : Query workflows with specific status, defaults to `""` (any status)
 
 GITHUB_EXPORTER_WORKFLOWS_HISTORY_WINDOW
-: Number of minutes to go back when querying for workflows since the time they were created, defaults to `720` (12 hours)
+: Duration for querying workflows since the time they were created, defaults to `12h`
+
 GITHUB_EXPORTER_COLLECTOR_RUNNERS
 : Enable collector for runners, defaults to `false`

--- a/docs/partials/metrics.md
+++ b/docs/partials/metrics.md
@@ -255,3 +255,6 @@ github_workflow_duration_ms{<prometheus.ConstrainedLabel Value>, <prometheus.Con
 
 github_workflow_status{<prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>}
 : Status of workflow runs
+
+github_workflow_duration_run_created_minutes{<prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>}
+: Duration since the workflow run creation time in minutes

--- a/docs/partials/metrics.md
+++ b/docs/partials/metrics.md
@@ -255,6 +255,3 @@ github_workflow_duration_ms{<prometheus.ConstrainedLabel Value>, <prometheus.Con
 
 github_workflow_status{<prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>}
 : Status of workflow runs
-
-github_workflow_duration_run_created_minutes{<prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>, <prometheus.ConstrainedLabel Value>}
-: Duration since the workflow run creation time in minutes

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -212,6 +212,20 @@ func RootFlags(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"GITHUB_EXPORTER_COLLECTOR_WORKFLOWS"},
 			Destination: &cfg.Collector.Workflows,
 		},
+		&cli.StringFlag{
+			Name:        "collector.workflows.status",
+			Value:       "",
+			Usage:       "Query workflows with specific status",
+			EnvVars:     []string{"GITHUB_EXPORTER_WORKFLOWS_STATUS"},
+			Destination: &cfg.Target.WorkflowsCfg.Status,
+		},
+		&cli.IntFlag{
+			Name:        "collector.workflows.history-window",
+			Value:       60 * 12,
+			Usage:       "Number of minutes to go back when querying for workflows since the time they were created",
+			EnvVars:     []string{"GITHUB_EXPORTER_WORKFLOWS_HISTORY_WINDOW"},
+			Destination: &cfg.Target.WorkflowsCfg.HistoryWindow,
+		},
 		&cli.BoolFlag{
 			Name:        "collector.runners",
 			Value:       false,

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -219,10 +219,10 @@ func RootFlags(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"GITHUB_EXPORTER_WORKFLOWS_STATUS"},
 			Destination: &cfg.Target.WorkflowsCfg.Status,
 		},
-		&cli.IntFlag{
+		&cli.DurationFlag{
 			Name:        "collector.workflows.history-window",
-			Value:       60 * 12,
-			Usage:       "Number of minutes to go back when querying for workflows since the time they were created",
+			Value:       12 * time.Hour,
+			Usage:       "Duration for querying workflows since the time they were created",
 			EnvVars:     []string{"GITHUB_EXPORTER_WORKFLOWS_HISTORY_WINDOW"},
 			Destination: &cfg.Target.WorkflowsCfg.HistoryWindow,
 		},

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -24,7 +24,7 @@ type Logs struct {
 // WorkflowsExporterConfig defines the workflow exporter specific configuration.
 type WorkflowsExporterConfig struct {
 	Status        string
-	HistoryWindow int
+	HistoryWindow time.Duration
 }
 
 // Target defines the target specific configuration.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,19 +21,26 @@ type Logs struct {
 	Pretty bool
 }
 
+// WorkflowsExporterConfig defines the workflow exporter specific configuration.
+type WorkflowsExporterConfig struct {
+	Status        string
+	HistoryWindow int
+}
+
 // Target defines the target specific configuration.
 type Target struct {
-	Token       string
-	PrivateKey  string
-	AppID       int64
-	InstallID   int64
-	BaseURL     string
-	Insecure    bool
-	Enterprises cli.StringSlice
-	Orgs        cli.StringSlice
-	Repos       cli.StringSlice
-	Timeout     time.Duration
-	PerPage     int
+	Token        string
+	PrivateKey   string
+	AppID        int64
+	InstallID    int64
+	BaseURL      string
+	Insecure     bool
+	Enterprises  cli.StringSlice
+	Orgs         cli.StringSlice
+	Repos        cli.StringSlice
+	Timeout      time.Duration
+	PerPage      int
+	WorkflowsCfg WorkflowsExporterConfig
 }
 
 // Collector defines the collector specific configuration.

--- a/pkg/exporter/workflow.go
+++ b/pkg/exporter/workflow.go
@@ -23,8 +23,9 @@ type WorkflowCollector struct {
 	duration *prometheus.HistogramVec
 	config   config.Target
 
-	Status   *prometheus.Desc
-	Duration *prometheus.Desc
+	Status      *prometheus.Desc
+	Duration    *prometheus.Desc
+	RunCreation *prometheus.Desc
 }
 
 // NewWorkflowCollector returns a new WorkflowCollector.
@@ -53,6 +54,12 @@ func NewWorkflowCollector(logger log.Logger, client *github.Client, failures *pr
 			labels,
 			nil,
 		),
+		RunCreation: prometheus.NewDesc(
+			"github_workflow_duration_run_created_minutes",
+			"Duration since the workflow run creation time in minutes",
+			labels,
+			nil,
+		),
 	}
 }
 
@@ -68,6 +75,7 @@ func (c *WorkflowCollector) Metrics() []*prometheus.Desc {
 func (c *WorkflowCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.Status
 	ch <- c.Duration
+	ch <- c.RunCreation
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
@@ -125,6 +133,13 @@ func (c *WorkflowCollector) Collect(ch chan<- prometheus.Metric) {
 			c.Duration,
 			prometheus.GaugeValue,
 			float64((record.GetUpdatedAt().Time.Unix()-record.GetCreatedAt().Time.Unix())*1000),
+			labels...,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.RunCreation,
+			prometheus.GaugeValue,
+			time.Since(record.GetRunStartedAt().Time).Minutes(),
 			labels...,
 		)
 	}
@@ -208,11 +223,12 @@ func (c *WorkflowCollector) repoWorkflows() []*github.WorkflowRun {
 
 func (c *WorkflowCollector) pagedRepoWorkflows(ctx context.Context, owner, name string) ([]*github.WorkflowRun, error) {
 	startWindow := time.Now().Add(
-		time.Duration(-12) * time.Hour,
+		time.Duration(-c.config.WorkflowsCfg.HistoryWindow) * time.Minute,
 	).Format(time.RFC3339)
 
 	opts := &github.ListWorkflowRunsOptions{
 		Created: fmt.Sprintf(">=%s", startWindow),
+		Status:  c.config.WorkflowsCfg.Status,
 		ListOptions: github.ListOptions{
 			PerPage: c.config.PerPage,
 		},

--- a/pkg/exporter/workflow.go
+++ b/pkg/exporter/workflow.go
@@ -34,7 +34,7 @@ func NewWorkflowCollector(logger log.Logger, client *github.Client, failures *pr
 		failures.WithLabelValues("action").Add(0)
 	}
 
-	labels := []string{"owner", "repo", "event", "name", "status", "head_branch", "run", "retry"}
+	labels := []string{"owner", "repo", "event", "name", "status", "head_branch", "run", "run_id", "retry"}
 	return &WorkflowCollector{
 		client:   client,
 		logger:   log.With(logger, "collector", "workflow"),
@@ -119,6 +119,7 @@ func (c *WorkflowCollector) Collect(ch chan<- prometheus.Metric) {
 			record.GetStatus(),
 			record.GetHeadBranch(),
 			strconv.Itoa(record.GetRunNumber()),
+			strconv.FormatInt(record.GetID(), 10),
 			strconv.Itoa(record.GetRunAttempt()),
 		}
 

--- a/pkg/exporter/workflow.go
+++ b/pkg/exporter/workflow.go
@@ -223,7 +223,7 @@ func (c *WorkflowCollector) repoWorkflows() []*github.WorkflowRun {
 
 func (c *WorkflowCollector) pagedRepoWorkflows(ctx context.Context, owner, name string) ([]*github.WorkflowRun, error) {
 	startWindow := time.Now().Add(
-		time.Duration(-c.config.WorkflowsCfg.HistoryWindow) * time.Minute,
+		-c.config.WorkflowsCfg.HistoryWindow,
 	).Format(time.RFC3339)
 
 	opts := &github.ListWorkflowRunsOptions{


### PR DESCRIPTION
Hi,

I wanted to identify stuck workflow runs, including ones that are queued and haven't started.
Runs that haven't started because they are queued, have the same updated time as the created time.

Changes:
1. I added a new metric for the duration, in minutes, of the time since the run was created.
2. Added 2 optional configuration options for the workflows exporter:
    2.1. Query workflows with a specific status (Default to any, as today)
    2.2. Set the window history (defaults to `12` hours as today).
3. Added run_id label

Thanks