### PR TITLE
Allow reading github token from path

### DIFF
--- a/changelog/unreleased/github-token-path.md
+++ b/changelog/unreleased/github-token-path.md
@@ -1,0 +1,6 @@
+Enhancement: Allow reading github token from path
+
+The `--github.token` now optionally accepts a file path as an argument.
+The program will read the contents of the file, and use it as the token.
+
+https://github.com/promhippie/github_exporter/issues/238


### PR DESCRIPTION
<!-- PLEASE READ BEFORE DELETING

Make sure to target the master branch, describe what your pull requests does and
which issue you are solving (if any). Please read our contributing guidelines as
well:

  https://github.com/promhippie/github_exporter/blob/master/CONTRIBUTING.md

-->

Hello!

This is an attempt at fixing #238. I had a look into urfave/cli, but it seems like the [`FilePath`](https://cli.urfave.org/v2/examples/flags/#values-from-files) option they provide, only allows you to set default values from files, not override functionality.

I'm a little bit unsure about the error logging. The logger seems to depend on the arguments, and the arguments (would) depend on the logger. I ended up just using standard `fmt` commands because I don't think it's worth the complexity, trying to partially parse arguments to set up a logger and then parse the rest. I could move the action function behind the part where the logger is created, but I think it makes sense to keep it as part of the command validation.

I have not written any go code before, so if something looks weird, don't assume I had my reasons :smile: 

Closes #238