### PR TITLE
Improve README.md to run in local debug mode in IDE

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ make generate build
 
 ./bin/github_exporter -h
 ```
+Inorder to run it in debug mode (from an IDE: goland etc) , ensure `GITHUB_EXPORTER_DATABASE_DSN` is set to a
+local write access path. Please add `-tags sqlite` in go tool arguments.
 
 ## Security
 


### PR DESCRIPTION
When trying to run this project via an IDE (goland), realised that we have to set the database environment variable to a local path with write access. Also need to give sqllite tag. Hence added them in the README.md. 