### PR TITLE
feat: make cardinality in github runner labels configurable

### DIFF
--- a/hack/generate-metrics-docs.go
+++ b/hack/generate-metrics-docs.go
@@ -26,6 +26,7 @@ func main() {
 
 	cfg := config.Load().Target
 	cfg.Workflows.Labels = *config.Labels()
+	cfg.Runners.Labels = *config.RunnerLabels()
 
 	collectors = append(
 		collectors,

--- a/pkg/command/command.go
+++ b/pkg/command/command.go
@@ -326,5 +326,12 @@ func RootFlags(cfg *config.Config) []cli.Flag {
 			EnvVars:     []string{"GITHUB_EXPORTER_COLLECTOR_RUNNERS"},
 			Destination: &cfg.Collector.Runners,
 		},
+		&cli.StringSliceFlag{
+			Name:        "collector.runners.labels",
+			Value:       config.RunnerLabels(),
+			Usage:       "List of labels used for runners",
+			EnvVars:     []string{"GITHUB_EXPORTER_RUNNERS_LABELS"},
+			Destination: &cfg.Target.Runners.Labels,
+		},
 	}
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -104,7 +104,7 @@ func Labels() *cli.StringSlice {
 	)
 }
 
-// Labels defines the default labels used by runner collector.
+// RunnerLabels defines the default labels used by runner collector.
 func RunnerLabels() *cli.StringSlice {
 	return cli.NewStringSlice(
 		"owner", "id", "name", "os", "status",

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,6 +37,11 @@ type Workflows struct {
 	Labels cli.StringSlice
 }
 
+// Runners defines the runner specific configuration.
+type Runners struct {
+	Labels cli.StringSlice
+}
+
 // Target defines the target specific configuration.
 type Target struct {
 	Token       string
@@ -51,6 +56,7 @@ type Target struct {
 	Timeout     time.Duration
 	PerPage     int
 	Workflows   Workflows
+	Runners     Runners
 }
 
 // Collector defines the collector specific configuration.
@@ -95,6 +101,13 @@ func Labels() *cli.StringSlice {
 		"branch",
 		"number",
 		"run",
+	)
+}
+
+// Labels defines the default labels used by runner collector.
+func RunnerLabels() *cli.StringSlice {
+	return cli.NewStringSlice(
+		"owner", "id", "name", "os", "status", "labels",
 	)
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -107,7 +107,7 @@ func Labels() *cli.StringSlice {
 // Labels defines the default labels used by runner collector.
 func RunnerLabels() *cli.StringSlice {
 	return cli.NewStringSlice(
-		"owner", "id", "name", "os", "status", "labels",
+		"owner", "id", "name", "os", "status",
 	)
 }
 


### PR DESCRIPTION
**Feature** : Make the labels to be retrieved by github runner configurable based on command line argument. 

**Context**: This PR is based on the discussion on a previous (now closed PR) . Reference : https://github.com/promhippie/github_exporter/pull/276 

**Changes**: Added a new `GITHUB_EXPORTER_RUNNERS_LABELS` command line argument where we mention the keys we need. For `labels` we return the name of the labels  of the runners . 
