### PR TITLE
Drop incoming webhook event if same timesatmp as existing completed event

### DIFF
--- a/changelog/unreleased/drop-incoming-event-if-same-ts-as-existing-completed.md
+++ b/changelog/unreleased/drop-incoming-event-if-same-ts-as-existing-completed.md
@@ -1,0 +1,9 @@
+Bugfix: Drop out of order incoming webhook event if same timesatmp as existing completed event
+
+We've fixed the behavior of out of order workflow events with the same
+timestamp, by preferring an already recorded `completed` event
+
+https://github.com/promhippie/github_exporter/issues/296
+https://github.com/promhippie/github_exporter/pull/298
+https://github.com/promhippie/github_exporter/pull/312
+

--- a/changelog/unreleased/drop-incoming-event-if-same-ts-as-existing-completed.md
+++ b/changelog/unreleased/drop-incoming-event-if-same-ts-as-existing-completed.md
@@ -1,4 +1,4 @@
-Bugfix: Drop out of order incoming webhook event if same timesatmp as existing completed event
+Bugfix: Drop out of order event if same timesatmp as existing completed event
 
 We've fixed the behavior of out of order workflow events with the same
 timestamp, by preferring an already recorded `completed` event

--- a/changelog/unreleased/drop-incoming-event-if-same-ts-as-existing-completed.md
+++ b/changelog/unreleased/drop-incoming-event-if-same-ts-as-existing-completed.md
@@ -1,4 +1,4 @@
-Bugfix: Drop out of order event if same timesatmp as existing completed event
+Bugfix: Drop out of order event if same timestamp as existing completed event
 
 We've fixed the behavior of out of order workflow events with the same
 timestamp, by preferring an already recorded `completed` event

--- a/pkg/store/generic.go
+++ b/pkg/store/generic.go
@@ -64,6 +64,11 @@ func createOrUpdateWorkflowRun(handle *sqlx.DB, record *WorkflowRun) error {
 	} else {
 		if existing.UpdatedAt > record.UpdatedAt {
 			return nil
+		} else if existing.UpdatedAt == record.UpdatedAt && existing.Status == "completed" {
+			// The updatedAt timestamp is in seconds, so if the existing record has
+			// the same timestamp as the new record, and the status is "completed",
+			// we can safely ignore the update.
+			return nil
 		}
 
 		if _, err := handle.NamedExec(


### PR DESCRIPTION
Hi,
This PR fixes another flavor of the bug described in issue https://github.com/promhippie/github_exporter/issues/296 and was previously fixed in PR https://github.com/promhippie/github_exporter/pull/298.
It is the same issue as before, where the `completed` event is received out of order, before the `in_progress` `skipped` event and the workflow is stuck in `in_progress` state forever. But, this time, both events got the same `updated_at` timestamp, therefore, based on the `updated_at` field only, it isn't clear which one is the newer one.
In this fix, if the incoming event has the same `updated_at` timestamp as the existing event, but the existing event is in `completed` status, the incoming event will be dropped.

I have also filled a bug report to GitHub to change the timestamps field on the GitHub webhook events to milliseconds or nanoseconds.

Thank you in advance,
Raz