### PR TITLE
fix(postgres): integer cannot fit github job ids

### DIFF
--- a/pkg/store/postgres.go
+++ b/pkg/store/postgres.go
@@ -73,6 +73,16 @@ var (
 				PRIMARY KEY(owner, repo, identifier)
 			);`,
 		},
+		{
+			Version:     4,
+			Description: "Fix identifier be BIGINT",
+			Script: `ALTER TABLE workflow_jobs ALTER COLUMN identifier TYPE BIGINT USING identifier::BIGINT;`,
+		},
+		{
+			Version:     5,
+			Description: "Fix run_id be BIGINT",
+			Script: `ALTER TABLE workflow_jobs ALTER COLUMN run_id TYPE BIGINT USING run_id::BIGINT;`,
+		},
 	}
 )
 


### PR DESCRIPTION
Tried migrating our sqlite backend to postgres and noticed there's a problem in
the pg schema:

```sh
"error":"failed to find record: pq: value \"32108935124\" is out of range for type integer"}
```

<!-- PLEASE READ BEFORE DELETING

Make sure to target the master branch, describe what your pull requests does and
which issue you are solving (if any). Please read our contributing guidelines as
well:

  https://github.com/promhippie/github_exporter/blob/master/CONTRIBUTING.md

-->
