### PR TITLE
feat(proxy): support proxy env vars

### DIFF
--- a/pkg/action/server.go
+++ b/pkg/action/server.go
@@ -417,16 +417,20 @@ func getClient(cfg *config.Config, logger *slog.Logger) (*github.Client, error) 
 		return nil, err
 	}
 
-	return github.NewClient(
-		oauth2.NewClient(
+	oauthHTTPClient := oauth2.NewClient(
 			context.Background(),
 			oauth2.StaticTokenSource(
 				&oauth2.Token{
 					AccessToken: accessToken,
 				},
 			),
-		),
-	), nil
+		)
+	
+	oauthHTTPClient.Transport = &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
+
+	return github.NewClient(oauthHTTPClient), nil
 }
 
 func getEnterprise(cfg *config.Config, logger *slog.Logger) (*github.Client, error) {


### PR DESCRIPTION
Guten Tag,

we can't really use `github_exporter` without being able to configure a proxy.

This PR adds support for HTTP/S Proxy via environment variables (`HTTP{S}_PROXY` & `http{s}_proxy`).

Note:
There is also a `github.NewClientWithEnvProxy()` func, which does what I want but we then would not be able to pass the ouath client to it. Perhaps you find a better way