### PR TITLE
fix: Update billing API endpoint

### DIFF
--- a/changelog/unreleased/api_billing_endpoint.md
+++ b/changelog/unreleased/api_billing_endpoint.md
@@ -1,0 +1,5 @@
+Fix: Migrating from the endpoints used for the previous billing platform
+
+Avoid failed fetching from billing API according to https://docs.github.com/en/enterprise-cloud@latest/billing/managing-your-billing/automating-usage-reporting#migrating-from-the-endpoints-used-for-the-previous-billing-platform
+
+https://github.com/promhippie/github_exporter/issues/496

--- a/changelog/unreleased/api_billing_endpoint.md
+++ b/changelog/unreleased/api_billing_endpoint.md
@@ -1,4 +1,4 @@
-Fix: Migrating from the endpoints used for the previous billing platform
+Change: Migrating from the endpoints used for the previous billing platform
 
 Avoid failed fetching from billing API according to https://docs.github.com/en/enterprise-cloud@latest/billing/managing-your-billing/automating-usage-reporting#migrating-from-the-endpoints-used-for-the-previous-billing-platform
 

--- a/pkg/exporter/billing.go
+++ b/pkg/exporter/billing.go
@@ -341,7 +341,7 @@ func (c *BillingCollector) getActionBilling() []*actionBilling {
 	for _, name := range c.config.Enterprises {
 		req, err := c.client.NewRequest(
 			"GET",
-			fmt.Sprintf("/enterprises/%s/settings/billing/actions", name),
+			fmt.Sprintf("/enterprises/%s/settings/billing/usage", name),
 			nil,
 		)
 


### PR DESCRIPTION
According to docs, Billing endpoint has been moved,
https://docs.github.com/en/enterprise-cloud@latest/billing/managing-your-billing/automating-usage-reporting#migrating-from-the-endpoints-used-for-the-previous-billing-platform

See https://github.com/promhippie/github_exporter/issues/496