### PR TITLE
fix(store): add missing fields to workflow queries

### DIFF
--- a/pkg/store/generic_workflow_job.go
+++ b/pkg/store/generic_workflow_job.go
@@ -164,7 +164,9 @@ ORDER BY
 
 var findWorkflowJobQuery = `
 SELECT
-	identifier
+	identifier,
+	created_at,
+	status
 FROM
 	workflow_jobs
 WHERE

--- a/pkg/store/generic_workflow_run.go
+++ b/pkg/store/generic_workflow_run.go
@@ -164,7 +164,8 @@ ORDER BY
 var findWorkflowRunQuery = `
 SELECT
 	identifier,
-	updated_at
+	updated_at,
+	status
 FROM
 	workflow_runs
 WHERE


### PR DESCRIPTION
Add status and updated_at to prevent unordered workflow events causing workflow to last indefinitely.

Referenced issue:
* https://github.com/promhippie/github_exporter/issues/710