### PR TITLE
feat: cumulative workflow job completion counters

### DIFF
--- a/docs/partials/metrics.md
+++ b/docs/partials/metrics.md
@@ -241,6 +241,9 @@ github_runner_repo_busy{owner, id, name, os, status}
 github_runner_repo_online{owner, id, name, os, status}
 : Static metrics of runner is online or not
 
+github_workflow_job_completed_total{owner, repo, workflow_name, name, conclusion}
+: Total number of completed workflow jobs
+
 github_workflow_job_created_timestamp{owner, repo, name, title, branch, sha, identifier, run_id, run_attempt, labels, runner_id, runner_name, runner_group_id, runner_group_name, workflow_name, conclusion}
 : Timestamp when the workflow job have been created
 
@@ -249,6 +252,9 @@ github_workflow_job_duration_ms{owner, repo, name, title, branch, sha, identifie
 
 github_workflow_job_duration_run_created_minutes{owner, repo, name, title, branch, sha, identifier, run_id, run_attempt, labels, runner_id, runner_name, runner_group_id, runner_group_name, workflow_name, conclusion}
 : Duration since the workflow run creation time in minutes
+
+github_workflow_job_duration_seconds_total{owner, repo, workflow_name, name, conclusion}
+: Total duration of completed workflow jobs in seconds
 
 github_workflow_job_started_timestamp{owner, repo, name, title, branch, sha, identifier, run_id, run_attempt, labels, runner_id, runner_name, runner_group_id, runner_group_name, workflow_name, conclusion}
 : Timestamp when the workflow job have been started

--- a/go.mod
+++ b/go.mod
@@ -15,6 +15,7 @@ require (
 	github.com/lib/pq v1.12.3
 	github.com/oklog/run v1.2.0
 	github.com/prometheus/client_golang v1.23.2
+	github.com/prometheus/client_model v0.6.2
 	github.com/prometheus/exporter-toolkit v0.17.1
 	github.com/ryanuber/go-glob v1.0.0
 	github.com/stretchr/testify v1.11.1
@@ -200,7 +201,6 @@ require (
 	github.com/pelletier/go-toml/v2 v2.3.1 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.69.0 // indirect
 	github.com/prometheus/procfs v0.17.0 // indirect
 	github.com/quasilyte/go-ruleguard v0.4.5 // indirect

--- a/pkg/exporter/workflow_job.go
+++ b/pkg/exporter/workflow_job.go
@@ -19,11 +19,13 @@ type WorkflowJobCollector struct {
 	duration *prometheus.HistogramVec
 	config   config.Target
 
-	Status   *prometheus.Desc
-	Duration *prometheus.Desc
-	Creation *prometheus.Desc
-	Created  *prometheus.Desc
-	Started  *prometheus.Desc
+	Status               *prometheus.Desc
+	Duration             *prometheus.Desc
+	Creation             *prometheus.Desc
+	Created              *prometheus.Desc
+	Started              *prometheus.Desc
+	CompletedTotal       *prometheus.Desc
+	DurationSecondsTotal *prometheus.Desc
 }
 
 // NewWorkflowJobCollector returns a new WorkflowCollector.
@@ -33,6 +35,14 @@ func NewWorkflowJobCollector(logger *slog.Logger, client *github.Client, db stor
 	}
 
 	labels := cfg.WorkflowJobs.Labels
+	completionLabels := []string{
+		"owner",
+		"repo",
+		"workflow_name",
+		"name",
+		"conclusion",
+	}
+
 	return &WorkflowJobCollector{
 		client:   client,
 		logger:   logger.With("collector", "workflow_job"),
@@ -71,6 +81,18 @@ func NewWorkflowJobCollector(logger *slog.Logger, client *github.Client, db stor
 			labels,
 			nil,
 		),
+		CompletedTotal: prometheus.NewDesc(
+			"github_workflow_job_completed_total",
+			"Total number of completed workflow jobs",
+			completionLabels,
+			nil,
+		),
+		DurationSecondsTotal: prometheus.NewDesc(
+			"github_workflow_job_duration_seconds_total",
+			"Total duration of completed workflow jobs in seconds",
+			completionLabels,
+			nil,
+		),
 	}
 }
 
@@ -82,6 +104,8 @@ func (c *WorkflowJobCollector) Metrics() []*prometheus.Desc {
 		c.Creation,
 		c.Created,
 		c.Started,
+		c.CompletedTotal,
+		c.DurationSecondsTotal,
 	}
 }
 
@@ -92,6 +116,8 @@ func (c *WorkflowJobCollector) Describe(ch chan<- *prometheus.Desc) {
 	ch <- c.Creation
 	ch <- c.Created
 	ch <- c.Started
+	ch <- c.CompletedTotal
+	ch <- c.DurationSecondsTotal
 }
 
 // Collect is called by the Prometheus registry when collecting metrics.
@@ -171,6 +197,45 @@ func (c *WorkflowJobCollector) Collect(ch chan<- prometheus.Metric) {
 			c.Started,
 			prometheus.GaugeValue,
 			float64(record.StartedAt),
+			labels...,
+		)
+	}
+
+	completions, err := c.db.GetWorkflowJobCompletions()
+
+	if err != nil {
+		c.logger.Error("Failed to fetch workflow job completions",
+			"err", err,
+		)
+
+		c.failures.WithLabelValues("workflow_job").Inc()
+		return
+	}
+
+	c.logger.Debug("Fetched workflow job completions",
+		"count", len(completions),
+	)
+
+	for _, completion := range completions {
+		labels := []string{
+			completion.Owner,
+			completion.Repo,
+			completion.WorkflowName,
+			completion.Name,
+			completion.Conclusion,
+		}
+
+		ch <- prometheus.MustNewConstMetric(
+			c.CompletedTotal,
+			prometheus.CounterValue,
+			float64(completion.Count),
+			labels...,
+		)
+
+		ch <- prometheus.MustNewConstMetric(
+			c.DurationSecondsTotal,
+			prometheus.CounterValue,
+			completion.DurationSecondsTotal,
 			labels...,
 		)
 	}

--- a/pkg/exporter/workflow_job_test.go
+++ b/pkg/exporter/workflow_job_test.go
@@ -1,7 +1,6 @@
 package exporter
 
 import (
-	"fmt"
 	"log/slog"
 	"os"
 	"reflect"
@@ -10,23 +9,12 @@ import (
 
 	"github.com/google/go-github/v89/github"
 	"github.com/prometheus/client_golang/prometheus"
+	dto "github.com/prometheus/client_model/go"
 	"github.com/promhippie/github_exporter/pkg/config"
 	"github.com/promhippie/github_exporter/pkg/store"
 )
 
 type StaticStore struct{}
-
-func (s StaticStore) GetWorkflowJobRuns(owner, repo, workflow string) ([]*store.WorkflowRun, error) {
-	_, _ = fmt.Fprintf(
-		os.Stdout,
-		"GetWorkflowJobRuns for %s/%s %s \n",
-		owner,
-		repo,
-		workflow,
-	)
-
-	return nil, nil
-}
 
 func (s StaticStore) StoreWorkflowRunEvent(*github.WorkflowRunEvent) error {
 	return nil
@@ -50,6 +38,10 @@ func (s StaticStore) GetWorkflowJobs(time.Duration) ([]*store.WorkflowJob, error
 
 func (s StaticStore) PruneWorkflowJobs(time.Duration) error {
 	return nil
+}
+
+func (s StaticStore) GetWorkflowJobCompletions() ([]*store.WorkflowJobCompletionAggregate, error) {
+	return nil, nil
 }
 
 func (s StaticStore) Open() (bool, error) {
@@ -118,6 +110,21 @@ func TestWorkflowJobCollector(t *testing.T) {
 			"Created time of the workflow job",
 			nil, nil,
 		),
+		Started: prometheus.NewDesc(
+			"workflow_job_started_timestamp_seconds",
+			"Started time of the workflow job",
+			nil, nil,
+		),
+		CompletedTotal: prometheus.NewDesc(
+			"workflow_job_completed_total",
+			"Total number of completed workflow jobs",
+			nil, nil,
+		),
+		DurationSecondsTotal: prometheus.NewDesc(
+			"workflow_job_duration_seconds_total",
+			"Total duration of completed workflow jobs in seconds",
+			nil, nil,
+		),
 	}
 
 	if collector.client != mockClient {
@@ -138,4 +145,105 @@ func TestWorkflowJobCollector(t *testing.T) {
 	if !reflect.DeepEqual(collector.config, mockConfig) {
 		t.Errorf("Expected config to be %v, got %v", mockConfig, collector.config)
 	}
+}
+
+type completionStore struct {
+	StaticStore
+	completions []*store.WorkflowJobCompletionAggregate
+}
+
+func (s completionStore) GetWorkflowJobCompletions() ([]*store.WorkflowJobCompletionAggregate, error) {
+	return s.completions, nil
+}
+
+func TestWorkflowJobCollectorCounters(t *testing.T) {
+	mockLogger := slog.New(
+		slog.NewTextHandler(os.Stdout, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		}),
+	)
+
+	mockFailures := prometheus.NewCounterVec(prometheus.CounterOpts{
+		Name: "test_failures_total",
+		Help: "Total number of test failures",
+	}, []string{"type"})
+
+	mockDuration := prometheus.NewHistogramVec(prometheus.HistogramOpts{
+		Name: "test_duration_seconds",
+		Help: "Duration of test",
+	}, []string{"type"})
+
+	completions := []*store.WorkflowJobCompletionAggregate{
+		{
+			Owner:                "promhippie",
+			Repo:                 "github_exporter",
+			WorkflowName:         "CI",
+			Name:                 "test",
+			Conclusion:           "success",
+			Count:                2,
+			DurationSecondsTotal: 42.5,
+		},
+		{
+			Owner:                "promhippie",
+			Repo:                 "github_exporter",
+			WorkflowName:         "CI",
+			Name:                 "test",
+			Conclusion:           "failure",
+			Count:                1,
+			DurationSecondsTotal: 10.0,
+		},
+	}
+
+	store := completionStore{completions: completions}
+	collector := NewWorkflowJobCollector(
+		mockLogger,
+		nil,
+		store,
+		mockFailures,
+		mockDuration,
+		config.Target{},
+	)
+
+	registry := prometheus.NewRegistry()
+	registry.MustRegister(collector)
+
+	metrics, err := registry.Gather()
+	if err != nil {
+		t.Fatalf("failed to gather metrics: %v", err)
+	}
+
+	expected := map[string]float64{
+		"github_workflow_job_completed_total":        3,
+		"github_workflow_job_duration_seconds_total": 52.5,
+	}
+
+	for name, expectedValue := range expected {
+		value := metricFamilyValue(t, metrics, name)
+		if value != expectedValue {
+			t.Errorf("expected %s to be %v, got %v", name, expectedValue, value)
+		}
+	}
+}
+
+func metricFamilyValue(t *testing.T, metrics []*dto.MetricFamily, name string) float64 {
+	t.Helper()
+
+	for _, mf := range metrics {
+		if mf.GetName() != name {
+			continue
+		}
+
+		var total float64
+
+		for _, m := range mf.GetMetric() {
+			if m.Counter != nil {
+				total += m.Counter.GetValue()
+			}
+		}
+
+		return total
+	}
+
+	t.Errorf("metric family %s not found", name)
+	return 0
 }

--- a/pkg/exporter/workflow_job_test.go
+++ b/pkg/exporter/workflow_job_test.go
@@ -111,17 +111,17 @@ func TestWorkflowJobCollector(t *testing.T) {
 			nil, nil,
 		),
 		Started: prometheus.NewDesc(
-			"workflow_job_started_timestamp_seconds",
-			"Started time of the workflow job",
+			"github_workflow_job_started_timestamp",
+			"Timestamp when the workflow job have been started",
 			nil, nil,
 		),
 		CompletedTotal: prometheus.NewDesc(
-			"workflow_job_completed_total",
+			"github_workflow_job_completed_total",
 			"Total number of completed workflow jobs",
 			nil, nil,
 		),
 		DurationSecondsTotal: prometheus.NewDesc(
-			"workflow_job_duration_seconds_total",
+			"github_workflow_job_duration_seconds_total",
 			"Total duration of completed workflow jobs in seconds",
 			nil, nil,
 		),

--- a/pkg/store/chai.go
+++ b/pkg/store/chai.go
@@ -73,6 +73,24 @@ var (
 				PRIMARY KEY(owner, repo, identifier)
 			);`,
 		},
+		{
+			Version:     4,
+			Description: "Creating table workflow_job_completions",
+			Script: `CREATE TABLE workflow_job_completions (
+				owner TEXT NOT NULL,
+				repo TEXT NOT NULL,
+				identifier BIGINT NOT NULL,
+				run_attempt INTEGER NOT NULL,
+				workflow_name TEXT,
+				name TEXT,
+				conclusion TEXT,
+				duration_seconds DOUBLE PRECISION,
+				recorded_at INTEGER,
+				PRIMARY KEY(owner, repo, identifier, run_attempt)
+			);
+			CREATE INDEX idx_workflow_job_completions_aggregate
+				ON workflow_job_completions(owner, repo, workflow_name, name, conclusion);`,
+		},
 	}
 )
 
@@ -164,6 +182,11 @@ func (s *chaiStore) GetWorkflowJobs(window time.Duration) ([]*WorkflowJob, error
 // PruneWorkflowJobs implements the Store interface.
 func (s *chaiStore) PruneWorkflowJobs(timeframe time.Duration) error {
 	return pruneWorkflowJobs(s.handle, timeframe)
+}
+
+// GetWorkflowJobCompletions implements the Store interface.
+func (s *chaiStore) GetWorkflowJobCompletions() ([]*WorkflowJobCompletionAggregate, error) {
+	return getWorkflowJobCompletions(s.handle)
 }
 
 func (s *chaiStore) dsn() string {

--- a/pkg/store/generic_workflow_job.go
+++ b/pkg/store/generic_workflow_job.go
@@ -37,7 +37,11 @@ func storeWorkflowJobEvent(handle *sqlx.DB, event *github.WorkflowJobEvent) erro
 		WorkflowName:    job.GetWorkflowName(),
 	}
 
-	return createOrUpdateWorkflowJob(handle, record)
+	if err := createOrUpdateWorkflowJob(handle, record); err != nil {
+		return err
+	}
+
+	return recordWorkflowJobCompletion(handle, record)
 }
 
 // createOrUpdateWorkflowJob creates or updates the record.
@@ -81,6 +85,60 @@ func createOrUpdateWorkflowJob(handle *sqlx.DB, record *WorkflowJob) error {
 	return nil
 }
 
+// recordWorkflowJobCompletion records a terminal workflow job event in an
+// append-only table. The first terminal payload for a given
+// (owner, repo, identifier, run_attempt) tuple wins; later payloads with the
+// same key are silently ignored to keep the Prometheus counters monotonic.
+func recordWorkflowJobCompletion(handle *sqlx.DB, record *WorkflowJob) error {
+	if record.Status != "completed" || record.Conclusion == "" {
+		return nil
+	}
+
+	duration := 0.0
+	startedAt := record.StartedAt
+	completedAt := record.CompletedAt
+
+	if startedAt > 0 && completedAt > 0 {
+		duration = float64(completedAt - startedAt)
+
+		if duration < 0 {
+			duration = 0
+		}
+	}
+
+	completion := &WorkflowJobCompletion{
+		Owner:           record.Owner,
+		Repo:            record.Repo,
+		Identifier:      record.Identifier,
+		RunAttempt:      record.RunAttempt,
+		WorkflowName:    record.WorkflowName,
+		Name:            record.Name,
+		Conclusion:      record.Conclusion,
+		DurationSeconds: duration,
+		RecordedAt:      time.Now().Unix(),
+	}
+
+	if _, err := handle.NamedExec(
+		createWorkflowJobCompletionQuery(handle.DriverName()),
+		completion,
+	); err != nil {
+		return fmt.Errorf("failed to record completion: %w", err)
+	}
+
+	return nil
+}
+
+// createWorkflowJobCompletionQuery returns the dialect-specific idempotent
+// insert for a workflow job completion.
+func createWorkflowJobCompletionQuery(driver string) string {
+	switch driver {
+	case "mysql", "mariadb":
+		return createWorkflowJobCompletionQueryMySQL
+	default:
+		return createWorkflowJobCompletionQueryDefault
+	}
+}
+
 // getWorkflowJobs retrieves the workflow jobs from the database.
 func getWorkflowJobs(handle *sqlx.DB, window time.Duration) ([]*WorkflowJob, error) {
 	records := make([]*WorkflowJob, 0)
@@ -114,6 +172,20 @@ func getWorkflowJobs(handle *sqlx.DB, window time.Duration) ([]*WorkflowJob, err
 	}
 
 	if err := rows.Err(); err != nil {
+		return records, err
+	}
+
+	return records, nil
+}
+
+// getWorkflowJobCompletions retrieves aggregated workflow job completions.
+func getWorkflowJobCompletions(handle *sqlx.DB) ([]*WorkflowJobCompletionAggregate, error) {
+	records := make([]*WorkflowJobCompletionAggregate, 0)
+
+	if err := handle.Select(
+		&records,
+		selectWorkflowJobCompletionsQuery,
+	); err != nil {
 		return records, err
 	}
 
@@ -241,3 +313,69 @@ DELETE FROM
 	workflow_jobs
 WHERE
 	created_at < :timeframe;`
+
+var createWorkflowJobCompletionQueryDefault = `
+INSERT INTO workflow_job_completions (
+	owner,
+	repo,
+	identifier,
+	run_attempt,
+	workflow_name,
+	name,
+	conclusion,
+	duration_seconds,
+	recorded_at
+) VALUES (
+	:owner,
+	:repo,
+	:identifier,
+	:run_attempt,
+	:workflow_name,
+	:name,
+	:conclusion,
+	:duration_seconds,
+	:recorded_at
+)
+ON CONFLICT DO NOTHING;`
+
+var createWorkflowJobCompletionQueryMySQL = `
+INSERT INTO workflow_job_completions (
+	owner,
+	repo,
+	identifier,
+	run_attempt,
+	workflow_name,
+	name,
+	conclusion,
+	duration_seconds,
+	recorded_at
+) VALUES (
+	:owner,
+	:repo,
+	:identifier,
+	:run_attempt,
+	:workflow_name,
+	:name,
+	:conclusion,
+	:duration_seconds,
+	:recorded_at
+)
+ON DUPLICATE KEY UPDATE owner=owner;`
+
+var selectWorkflowJobCompletionsQuery = `
+SELECT
+	owner,
+	repo,
+	workflow_name,
+	name,
+	conclusion,
+	COUNT(*) AS count,
+	COALESCE(SUM(duration_seconds), 0.0) AS duration_seconds_total
+FROM
+	workflow_job_completions
+GROUP BY
+	owner,
+	repo,
+	workflow_name,
+	name,
+	conclusion;`

--- a/pkg/store/mysql.go
+++ b/pkg/store/mysql.go
@@ -73,6 +73,28 @@ var (
 				PRIMARY KEY(owner, repo, identifier)
 			);`,
 		},
+		{
+			Version:     4,
+			Description: "Creating table workflow_job_completions",
+			Script: `CREATE TABLE workflow_job_completions (
+				owner VARCHAR(64) NOT NULL,
+				repo VARCHAR(100) NOT NULL,
+				identifier BIGINT NOT NULL,
+				run_attempt INTEGER NOT NULL,
+				workflow_name VARCHAR(128),
+				name VARCHAR(128),
+				conclusion VARCHAR(64),
+				duration_seconds DOUBLE,
+				recorded_at BIGINT,
+				PRIMARY KEY(owner, repo, identifier, run_attempt)
+			) ENGINE=InnoDB CHARACTER SET=utf8;`,
+		},
+		{
+			Version:     5,
+			Description: "Creating index for workflow_job_completions aggregate",
+			Script: `CREATE INDEX idx_workflow_job_completions_aggregate
+				ON workflow_job_completions(owner, repo, workflow_name, name, conclusion);`,
+		},
 	}
 )
 
@@ -175,6 +197,11 @@ func (s *mysqlStore) GetWorkflowJobs(window time.Duration) ([]*WorkflowJob, erro
 // PruneWorkflowJobs implements the Store interface.
 func (s *mysqlStore) PruneWorkflowJobs(timeframe time.Duration) error {
 	return pruneWorkflowJobs(s.handle, timeframe)
+}
+
+// GetWorkflowJobCompletions implements the Store interface.
+func (s *mysqlStore) GetWorkflowJobCompletions() ([]*WorkflowJobCompletionAggregate, error) {
+	return getWorkflowJobCompletions(s.handle)
 }
 
 func (s *mysqlStore) dsn() string {

--- a/pkg/store/postgres.go
+++ b/pkg/store/postgres.go
@@ -83,6 +83,24 @@ var (
 			Description: "Fix run_id be BIGINT",
 			Script:      `ALTER TABLE workflow_jobs ALTER COLUMN run_id TYPE BIGINT USING run_id::BIGINT;`,
 		},
+		{
+			Version:     6,
+			Description: "Creating table workflow_job_completions",
+			Script: `CREATE TABLE workflow_job_completions (
+				owner TEXT NOT NULL,
+				repo TEXT NOT NULL,
+				identifier BIGINT NOT NULL,
+				run_attempt INTEGER NOT NULL,
+				workflow_name TEXT,
+				name TEXT,
+				conclusion TEXT,
+				duration_seconds DOUBLE PRECISION,
+				recorded_at BIGINT,
+				PRIMARY KEY(owner, repo, identifier, run_attempt)
+			);
+			CREATE INDEX idx_workflow_job_completions_aggregate
+				ON workflow_job_completions(owner, repo, workflow_name, name, conclusion);`,
+		},
 	}
 )
 
@@ -185,6 +203,11 @@ func (s *postgresStore) GetWorkflowJobs(window time.Duration) ([]*WorkflowJob, e
 // PruneWorkflowJobs implements the Store interface.
 func (s *postgresStore) PruneWorkflowJobs(timeframe time.Duration) error {
 	return pruneWorkflowJobs(s.handle, timeframe)
+}
+
+// GetWorkflowJobCompletions implements the Store interface.
+func (s *postgresStore) GetWorkflowJobCompletions() ([]*WorkflowJobCompletionAggregate, error) {
+	return getWorkflowJobCompletions(s.handle)
 }
 
 func (s *postgresStore) dsn() string {

--- a/pkg/store/sqlite.go
+++ b/pkg/store/sqlite.go
@@ -74,6 +74,24 @@ var (
 				PRIMARY KEY(owner, repo, identifier)
 			);`,
 		},
+		{
+			Version:     4,
+			Description: "Creating table workflow_job_completions",
+			Script: `CREATE TABLE workflow_job_completions (
+				owner TEXT NOT NULL,
+				repo TEXT NOT NULL,
+				identifier BIGINT NOT NULL,
+				run_attempt INTEGER NOT NULL,
+				workflow_name TEXT,
+				name TEXT,
+				conclusion TEXT,
+				duration_seconds REAL,
+				recorded_at BIGINT,
+				PRIMARY KEY(owner, repo, identifier, run_attempt)
+			);
+			CREATE INDEX idx_workflow_job_completions_aggregate
+				ON workflow_job_completions(owner, repo, workflow_name, name, conclusion);`,
+		},
 	}
 )
 
@@ -172,6 +190,11 @@ func (s *sqliteStore) GetWorkflowJobs(window time.Duration) ([]*WorkflowJob, err
 // PruneWorkflowJobs implements the Store interface.
 func (s *sqliteStore) PruneWorkflowJobs(timeframe time.Duration) error {
 	return pruneWorkflowJobs(s.handle, timeframe)
+}
+
+// GetWorkflowJobCompletions implements the Store interface.
+func (s *sqliteStore) GetWorkflowJobCompletions() ([]*WorkflowJobCompletionAggregate, error) {
+	return getWorkflowJobCompletions(s.handle)
 }
 
 func (s *sqliteStore) dsn() string {

--- a/pkg/store/store.go
+++ b/pkg/store/store.go
@@ -30,6 +30,7 @@ type Store interface {
 	StoreWorkflowJobEvent(*github.WorkflowJobEvent) error
 	GetWorkflowJobs(time.Duration) ([]*WorkflowJob, error)
 	PruneWorkflowJobs(time.Duration) error
+	GetWorkflowJobCompletions() ([]*WorkflowJobCompletionAggregate, error)
 
 	Open() (bool, error)
 	Close() error

--- a/pkg/store/types.go
+++ b/pkg/store/types.go
@@ -126,3 +126,30 @@ func (r *WorkflowJob) ByLabel(label string) string {
 
 	return ""
 }
+
+// WorkflowJobCompletion defines the append-only record of a terminal workflow
+// job event. Each (owner, repo, identifier, run_attempt) tuple is recorded at
+// most once; the first terminal payload wins.
+type WorkflowJobCompletion struct {
+	Owner           string  `db:"owner"`
+	Repo            string  `db:"repo"`
+	Identifier      int64   `db:"identifier"`
+	RunAttempt      int     `db:"run_attempt"`
+	WorkflowName    string  `db:"workflow_name"`
+	Name            string  `db:"name"`
+	Conclusion      string  `db:"conclusion"`
+	DurationSeconds float64 `db:"duration_seconds"`
+	RecordedAt      int64   `db:"recorded_at"`
+}
+
+// WorkflowJobCompletionAggregate groups completion records for counter
+// emission.
+type WorkflowJobCompletionAggregate struct {
+	Owner                string  `db:"owner"`
+	Repo                 string  `db:"repo"`
+	WorkflowName         string  `db:"workflow_name"`
+	Name                 string  `db:"name"`
+	Conclusion           string  `db:"conclusion"`
+	Count                int64   `db:"count"`
+	DurationSecondsTotal float64 `db:"duration_seconds_total"`
+}


### PR DESCRIPTION
Adds `github_workflow_job_completed_total` and `github_workflow_job_duration_seconds_total` counters for completed workflow jobs, with a fixed low-cardinality label set (owner, repo, workflow_name, name, conclusion).

To keep the counters monotonic an append-only `workflow_job_completions` table is introduced, keyed by (owner, repo, identifier, run_attempt). The first terminal payload wins; later redeliveries with the same key are silently ignored via driver-specific idempotent inserts. Existing gauge metrics remain unchanged.

Closes #712